### PR TITLE
upgrade to latest version of utest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ scalaVersion  := "2.11.7"
 crossScalaVersions := Seq("2.10.4", "2.11.7")
 
 libraryDependencies ++= Seq(
-  "com.lihaoyi" %% "utest" % "0.3.1" % "test",
+  "com.lihaoyi" %% "utest" % "0.4.3" % "test",
   "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided"
 )
 

--- a/src/test/scala/acyclic/TestUtils.scala
+++ b/src/test/scala/acyclic/TestUtils.scala
@@ -6,7 +6,7 @@ import tools.nsc.plugins.Plugin
 
 import java.net.URLClassLoader
 import scala.tools.nsc.util.ClassPath
-import utest._
+import utest._, asserts._
 import scala.reflect.io.VirtualDirectory
 import acyclic.plugin.Value
 import scala.collection.SortedSet


### PR DESCRIPTION
seems like a good thing in general, but also resolves a source
incompatibility for the Scala community build
(https://github.com/scala/scala-dev/issues/108)