### PR TITLE
Increment version number

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -174,11 +174,11 @@ How to Use
 To use, add the following to your `build.sbt`:
 
 ```scala
-libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.1.4" % "provided"
+libraryDependencies += "com.lihaoyi" %% "acyclic" % "0.1.5" % "provided"
 
 autoCompilerPlugins := true
 
-addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.4")
+addCompilerPlugin("com.lihaoyi" %% "acyclic" % "0.1.5")
 ```
 
 If you are on Scala 2.10.x, you may need an additional compile-time dependency:


### PR DESCRIPTION
The version number in the README is one behind the latest release. This is important because version 0.1.4 does not support Scala 2.12