### PR TITLE
Check cycles on package level

### DIFF
--- a/src/main/scala/acyclic/plugin/Plugin.scala
+++ b/src/main/scala/acyclic/plugin/Plugin.scala
@@ -11,16 +11,20 @@ class TestPlugin(val global: Global,
   val name = "acyclic"
 
   var force = false
+  var forcePkg = false
   // Yeah processOptions is deprecated but keep using it anyway for 2.10.x compatibility
   override def processOptions(options: List[String], error: String => Unit): Unit = {
     if (options.contains("force")) {
       force = true
+    }
+    if(options.contains("forcePkg")){
+      forcePkg = true
     }
   }
   val description = "Allows the developer to prohibit inter-file dependencies"
 
 
   val components = List[tools.nsc.plugins.PluginComponent](
-    new PluginPhase(this.global, cycleReporter, force)
+    new PluginPhase(this.global, cycleReporter, force, forcePkg)
   )
 }

--- a/src/test/resources/forcepkg/cyclicpackage/a/A1.scala
+++ b/src/test/resources/forcepkg/cyclicpackage/a/A1.scala
@@ -1,0 +1,6 @@
+package forcepkg.cyclicpackage
+package a
+
+class A1 extends b.B1{
+
+}

--- a/src/test/resources/forcepkg/cyclicpackage/a/A2.scala
+++ b/src/test/resources/forcepkg/cyclicpackage/a/A2.scala
@@ -1,0 +1,5 @@
+package forcepkg.cyclicpackage.a
+
+class A2 {
+
+}

--- a/src/test/resources/forcepkg/cyclicpackage/b/B1.scala
+++ b/src/test/resources/forcepkg/cyclicpackage/b/B1.scala
@@ -1,0 +1,3 @@
+package forcepkg.cyclicpackage.b
+
+class B1

--- a/src/test/resources/forcepkg/cyclicpackage/b/B2.scala
+++ b/src/test/resources/forcepkg/cyclicpackage/b/B2.scala
@@ -1,0 +1,4 @@
+package forcepkg.cyclicpackage
+package b
+
+class B2 extends a.A2

--- a/src/test/resources/forcepkg/simple/A.scala
+++ b/src/test/resources/forcepkg/simple/A.scala
@@ -1,0 +1,6 @@
+package forcepkg.simple
+
+
+class A {
+  val b: B = null
+}

--- a/src/test/resources/forcepkg/simple/B.scala
+++ b/src/test/resources/forcepkg/simple/B.scala
@@ -1,0 +1,6 @@
+package forcepkg.simple
+
+class B {
+  val a1: A = new A
+  val a2: A = new A
+}

--- a/src/test/scala/acyclic/CycleTests.scala
+++ b/src/test/scala/acyclic/CycleTests.scala
@@ -60,6 +60,7 @@ object CycleTests extends TestSuite{
       ))
       'pass-make("force/simple")
       'skip-make("force/skip", force = true)
+      "mutualcyclic"-make("success/pkg/mutualcyclic", force = true)
     }
     'forcepkg{
       'fail-makeFail("forcepkg/cyclicpackage", force = false, forcePkg = true)(

--- a/src/test/scala/acyclic/CycleTests.scala
+++ b/src/test/scala/acyclic/CycleTests.scala
@@ -2,7 +2,6 @@ package acyclic
 
 import utest._
 import TestUtils.{make, makeFail}
-import scala.tools.nsc.util.ScalaClassLoader.URLClassLoader
 import acyclic.plugin.Value.{Pkg, File}
 import scala.collection.SortedSet
 import acyclic.file
@@ -61,6 +60,21 @@ object CycleTests extends TestSuite{
       ))
       'pass-make("force/simple")
       'skip-make("force/skip", force = true)
+    }
+    'forcepkg{
+      'fail-makeFail("forcepkg/cyclicpackage", force = false, forcePkg = true)(
+        Seq(
+          Pkg("forcepkg.cyclicpackage.b") -> SortedSet(4),
+          Pkg("forcepkg.cyclicpackage.a") -> SortedSet(4)
+        )
+      )
+      'success-make("forcepkg/simple", force = false, forcePkg = true)
+      'fail-makeFail("forcepkg/simple", force = true, forcePkg = true)(
+        Seq(
+          File("B.scala") -> SortedSet(4, 5),
+          File("A.scala") -> SortedSet(5)
+        )
+      )
     }
   }
 }


### PR DESCRIPTION
Hi, 

I noticed that even if the force flag is set, cycles between packages are not checked until an explicit package object is provided. This is quite cumbersome since it required manually adding such package object whenever a new package is created.

This PR adds `forcePkg` flag which fixes that behavior.